### PR TITLE
refactor querry service

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -27,6 +27,7 @@
         "@types/node": "^24.3.1",
         "@types/sqlite3": "^3.1.11",
         "@types/supertest": "^6.0.3",
+        "cross-env": "^10.1.0",
         "jest": "^30.1.3",
         "nodemon": "^3.1.10",
         "supertest": "^7.1.4",
@@ -608,6 +609,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -3004,6 +3012,24 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "main": "index.ts",
   "scripts": {
     "dev": "ts-node-dev --respawn src/server.ts",
-    "test": "NODE_ENV=test jest --detectOpenHandles --forceExit",
+    "test": "cross-env NODE_ENV=test jest --detectOpenHandles --forceExit",
     "build": "tsc",
     "start": "node dist/server.js"
   },
@@ -30,6 +30,7 @@
     "@types/node": "^24.3.1",
     "@types/sqlite3": "^3.1.11",
     "@types/supertest": "^6.0.3",
+    "cross-env": "^10.1.0",
     "jest": "^30.1.3",
     "nodemon": "^3.1.10",
     "supertest": "^7.1.4",

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -1,29 +1,40 @@
 import { User } from '../models/user.model';
-import { query } from './db.service';
+import { dbAll, dbGet, dbRun } from './db.service';
 
 
 export async function getAllUsers(): Promise<User[]> {
-    const result = await query('SELECT * FROM users;');
-    return result.rows;
+    // Use dbAll and specify the return type
+    const users = await dbAll<User>('SELECT * FROM users;');
+    return users;
 }
 
 export async function getUser(email: string): Promise<User | null> {
-    const result = await query('SELECT * FROM users WHERE email = ?;', [email]);
-    return result.rows[0] || null;
+    // Use dbGet and specify the return type
+    const user = await dbGet<User>('SELECT * FROM users WHERE email = ?;', [email]);
+    return user || null;
 }
 
 export async function getUserByCpf(cpf: string): Promise<User | null> {
-    const result = await query('SELECT * FROM users WHERE cpf = ?;', [cpf]);
-    return result.rows[0] || null;
+    // Use dbGet
+    const user = await dbGet<User>('SELECT * FROM users WHERE cpf = ?;', [cpf]);
+    return user || null;
 }
 
 export async function createUser(user: Omit<User, 'id' | 'created_at'>): Promise<User | null> {
-    const result = await query(
+    // 1. Run the INSERT query
+    const result = await dbRun(
         `INSERT INTO users (firstName, lastName, cpf, email, phone, birthday, password) 
-         VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING *;`,
+         VALUES (?, ?, ?, ?, ?, ?, ?);`,
         [user.firstName, user.lastName, user.cpf, user.email, user.phone, user.birthday, user.password]
     );
 
-    return result.rows[0] || null;
-}
+    // 2. Get the lastID from the result
+    const newUserId = result.lastID;
+    if (!newUserId) {
+        return null;
+    }
 
+    // 3. Explicitly fetch the user we just created
+    const newUser = await dbGet<User>('SELECT * FROM users WHERE id = ?;', [newUserId]);
+    return newUser || null;
+}


### PR DESCRIPTION
The `createUser` function in `user.service.ts` only works due to hardcoded logic.  
Refactored `db.service.ts` to export the raw SQLite methods (`run`, `get`, `all`).  
Now, services like `user.service` are responsible for writing their own SQL, while `db.service` just provides the execution tools.

**Note:** Added `cross-env` to enable running tests on Windows.
